### PR TITLE
[refactor, feat] 날씨 메인/시간별 UI 개선 및 주간 예보 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import WeatherMainCard from "./components/WeatherMainCard";
-import HourlyForecastCard from "./components/HourlyForecastCard";
 import HourlyForecastSection from "./components/HourlyForecastSection";
+import WeeklyForecastSection from "./components/WeeklyForecastSection";
 
 function App() {
   return (
@@ -8,12 +8,9 @@ function App() {
       <aside className="w-[248px] bg-white shadow-md shrink-0"></aside>
 
       <main className="flex flex-1 px-[296px] py-[75.5px] flex-col gap-[24px] items-center justify-center ">
-        <WeatherMainCard
-          temperature={12.2}
-          location="롯데월드"
-          date="4월 26일"
-        />
+        <WeatherMainCard />
         <HourlyForecastSection />
+        <WeeklyForecastSection />
       </main>
     </div>
   );

--- a/src/components/HourlyForecastCard.tsx
+++ b/src/components/HourlyForecastCard.tsx
@@ -1,15 +1,13 @@
-type Props = {
-  time: string;
-  icon: string;
-  temperature: string;
-};
+import type { HourlyForecast } from "../types/weather";
 
-export default function HourlyForecastCard({ time, icon, temperature }: Props) {
+export default function HourlyForecastCard(props: HourlyForecast) {
+  const { time, icon, temperature } = props;
+
   return (
     <div className="flex flex-col items-center w-[48px] gap-2">
       <img src={icon} alt="weather icon" className="w-10 h-10" />
-      <span className="text-sm text-gray-500">{time}</span>
-      <span className="text-sm">{temperature}</span>
+      <span className="text-[12px] text-[#A4A4A4]">{time}</span>
+      <span className="text-[12px] text-[#292E2E] ">{temperature}</span>
     </div>
   );
 }

--- a/src/components/HourlyForecastSection.tsx
+++ b/src/components/HourlyForecastSection.tsx
@@ -18,7 +18,7 @@ const hourlyData = [
 export default function HourlyForecastSection() {
   return (
     <section className="w-full max-w-[1328px] bg-white rounded-[16px] border-[2px] border-[#F2F2F2] shadow-[0_0_8px_2px_rgba(0,0,0,0.1)] p-6 flex flex-col gap-6">
-      <h3 className="text-base font-bold">시간별 현황</h3>
+      <h3 className="text-[20px] font-bold">시간별 현황</h3>
       <div className="flex flex-col gap-2 px-6 py-3">
         <div className="overflow-x-auto scrollbar-hide">
           <div className="relative flex gap-4 w-max">

--- a/src/components/WeatherInfoCard.tsx
+++ b/src/components/WeatherInfoCard.tsx
@@ -1,22 +1,14 @@
-type Props = {
-  label: string;
-  value: string;
-  colorClass: string;
-  valueTextClass: string;
-};
+import type { WeatherInfo } from "../types/weather";
 
-export default function WeatherInfoCard({
-  label,
-  value,
-  colorClass,
-  valueTextClass,
-}: Props) {
+export default function WeatherInfoCard(props: WeatherInfo) {
+  const { label, value, colorClass, valueTextClass } = props;
+
   return (
     <div
       className={`flex flex-col items-center gap-[10px] w-[120px] px-[24px] py-[12px] rounded-[12px] ${colorClass}`}
     >
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className={`text-base font-semibold ${valueTextClass}`}>{value}</p>
+      <p className="text-[12px] text-[#292E2E] font-medium">{label}</p>
+      <p className={`text-base font-bold ${valueTextClass}`}>{value}</p>
     </div>
   );
 }

--- a/src/components/WeatherMainCard.tsx
+++ b/src/components/WeatherMainCard.tsx
@@ -1,20 +1,19 @@
 import WeatherInfoCard from "./WeatherInfoCard";
+import type { WeatherMainCard } from "../types/weather";
 
-interface WeatherMainCardProps {
-  temperature: number;
-  location: string;
-  date: string;
-}
+const weatherMainCardData: WeatherMainCard = {
+  temperature: 12.2,
+  location: "롯데월드",
+  date: "4월 26일",
+};
 
-export default function WeatherMainCard({
-  temperature,
-  location,
-  date,
-}: WeatherMainCardProps) {
+export default function WeatherMainCard() {
+  const { temperature, location, date } = weatherMainCardData;
+
   return (
     <section className="w-full max-w-[1328px] bg-white rounded-[16px] border-[2px] border-[#F2F2F2] shadow-[0_0_8px_2px_rgba(0,0,0,0.1)] p-8 flex flex-col gap-[12px]">
       <div>
-        <h2 className="text-lg font-bold text-left">
+        <h2 className="text-xl font-bold text-left">
           {date} {location} 날씨 현황
         </h2>
       </div>
@@ -22,11 +21,21 @@ export default function WeatherMainCard({
       <div className="flex flex-col items-center gap-2.5 p-2.5">
         <div className="flex items-center gap-2.5">
           <div className="w-20 h-20 bg-gray-200 rounded-full"></div>
-          <p className="text-5xl font-bold">{temperature}°</p>
+          <p className="text-[80px] font-bold">{temperature}°</p>
         </div>
-        <p className="text-base font-medium">야간 / 흐림</p>
-        <p className="text-sm text-gray-500">
-          체감 9.0° · 습도 48% · 남동풍 0.4m/s
+        <p className="text-xl font-semibold">야간 / 흐림</p>
+        <p className="flex items-center gap-[8px] text-base text-[#A4A4A4] font-medium">
+          <span>
+            체감<span className="text-[#292E2E]">9.0°</span>
+          </span>
+          <span className="w-[4px] h-[4px] bg-[#A4A4A4] rounded-full" />
+          <span>
+            습도<span className="text-[#292E2E]">48%</span>
+          </span>
+          <span className="w-[4px] h-[4px] bg-[#C6C6C6] rounded-full" />
+          <span>
+            남동풍 <span className="text-[#292E2E]">0.4m/s</span>
+          </span>
         </p>
       </div>
 

--- a/src/components/WeeklyForecastCard.tsx
+++ b/src/components/WeeklyForecastCard.tsx
@@ -1,0 +1,43 @@
+import type { WeeklyForecast } from "../types/weather";
+
+export default function WeeklyForecastCard(props: WeeklyForecast) {
+  const { date, weekday, am, pm } = props;
+
+  return (
+    <div className="flex flex-col items-center text-center  shrink-0">
+      <div className="flex flex-row justify-center gap-4">
+        {/* AM */}
+        <div className="flex flex-col items-center py-2 gap-3  max-w-[60px]">
+          <img src={am.icon} alt="오전 아이콘" className="w-[60px] h-[60px]" />
+          {am.rainRate !== undefined && (
+            <div className="text-[20px] font-bold text-[#CCE8FF]">
+              {am.rainRate}%
+            </div>
+          )}
+          <span className="text-[16px] font-bold text-[#292E2E]">오전</span>
+          <span className="text-[16px] font-bold text-[#32A1FF]">
+            {am.temp}°
+          </span>
+        </div>
+
+        {/* PM */}
+        <div className="flex flex-col items-center py-2 gap-3">
+          <img src={pm.icon} alt="오후 아이콘" className="w-[60px] h-[60px]" />
+          {pm.rainRate !== undefined && (
+            <div className="text-[20px] font-bold text-[#CCE8FF]">
+              {pm.rainRate}%
+            </div>
+          )}
+          <span className="text-[16px] font-bold text-[#292E2E]">오후</span>
+          <span className="text-[16px] font-bold text-red-500">{pm.temp}°</span>
+        </div>
+      </div>
+
+      <div className="text-[16px] font-medium text-[#292E2E] leading-tight">
+        {weekday}
+        <br />
+        {date}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeeklyForecastSection.tsx
+++ b/src/components/WeeklyForecastSection.tsx
@@ -1,0 +1,47 @@
+import WeeklyForecastCard from "../components/WeeklyForecastCard";
+import type { WeeklyForecast } from "../types/weather";
+
+const weeklyData: WeeklyForecast[] = [
+  {
+    date: "4.26",
+    weekday: "오늘",
+    am: { icon: "/icons/Sun.png", temp: 10, rainRate: 10 },
+    pm: { icon: "/icons/Clouds.png", temp: 17, rainRate: 20 },
+  },
+  {
+    date: "4.27",
+    weekday: "토",
+    am: { icon: "/icons/Snow.png", temp: 4, rainRate: 40 },
+    pm: { icon: "/icons/Sun.png", temp: 13, rainRate: 10 },
+  },
+  {
+    date: "4.28",
+    weekday: "일",
+
+    am: { icon: "/icons/Sun.png", temp: 6, rainRate: 0 },
+    pm: { icon: "/icons/Rain.png", temp: 16, rainRate: 30 },
+  },
+  {
+    date: "4.29",
+    weekday: "월",
+
+    am: { icon: "/icons/Sun.png", temp: 6, rainRate: 0 },
+    pm: { icon: "/icons/Rain.png", temp: 16, rainRate: 30 },
+  },
+];
+
+export default function WeeklyForecastSection() {
+  return (
+    <section className="w-full max-w-[1328px] bg-white rounded-[16px] border-[2px] border-[#F2F2F2] shadow-[0_0_8px_2px_rgba(0,0,0,0.1)] p-6 flex flex-col gap-6">
+      <h3 className="text-[20px] font-bold">주간 예보</h3>
+
+      <div className="overflow-x-auto px-[24px] py-3">
+        <div className="flex w-full justify-between">
+          {weeklyData.map((day) => (
+            <WeeklyForecastCard key={day.date} {...day} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/types/weather.ts
+++ b/src/types/weather.ts
@@ -1,0 +1,31 @@
+export type WeatherInfo = {
+  label: string;
+  value: string;
+  colorClass: string;
+  valueTextClass: string;
+};
+
+export type WeatherMainCard = {
+  temperature: number;
+  location: string;
+  date: string;
+};
+
+export type HourlyForecast = {
+  time: string;
+  icon: string;
+  temperature: string;
+};
+
+export type ForecastItem = {
+  icon: string;
+  temp: number;
+  rainRate?: number;
+};
+
+export type WeeklyForecast = {
+  date: string;
+  weekday: string;
+  am: ForecastItem;
+  pm: ForecastItem;
+};


### PR DESCRIPTION
## 📎 관련 이슈

Closes #5 

## 💡 작업 내용 요약

- WeatherMainCard: 텍스트 강조, ● 구분자 추가, 폰트/간격 스타일 수정
- HourlyForecastSection/Card: 텍스트 스타일 및 폰트 사이즈 조정
- WeeklyForecastCard/Section 컴포넌트 생성 및 UI 구현
  - 오전/오후 구분 레이아웃, 강수 확률, 온도, 요일 및 날짜 표시
- weather 타입 정의 정리 및 WeeklyForecast 타입 작성
## 📸 스크린샷 (선택)



## 📝 기타
- 더미 데이터는 컴포넌트 내에 임시 정의
- 향후 API 연동 시 `data/` 폴더로 분리 예정